### PR TITLE
Refactor/#47 bundle font style define and page compoenent refactor

### DIFF
--- a/src/components/AlignSelectMenu/index.jsx
+++ b/src/components/AlignSelectMenu/index.jsx
@@ -4,6 +4,7 @@ import bottomArrow from '@/assets/icons/arrows/chevron_down.svg';
 
 import { defaultBorderBoxStyle } from '@/styles/commonStyle/box';
 import { centerAlignStyle } from '@/styles/commonStyle/etc';
+import { xsmall_400 } from '@/styles/commonStyle/localTextStyle';
 
 const SelectBox = styled.div`
   ${defaultBorderBoxStyle}
@@ -11,12 +12,7 @@ const SelectBox = styled.div`
   width: 95px;
   height: 35px;
   padding: 0 10px;
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.xs;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.regular;
-  }};
+  ${xsmall_400}
   > div:first-child {
     width: 100%;
     display: flex;

--- a/src/components/Icons/style.js
+++ b/src/components/Icons/style.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import { xsmall_500 } from '@/styles/commonStyle/localTextStyle';
 export const IconBox = styled.div`
   display: flex;
   align-items: center;
@@ -9,11 +10,6 @@ export const IconBox = styled.div`
     color: ${({ theme: { colors } }) => {
       return colors.gray['60'];
     }};
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.xs;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.medium;
-    }};
+    ${xsmall_500}
   }
 `;

--- a/src/components/PageCategory/index.jsx
+++ b/src/components/PageCategory/index.jsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import rightArrow from '@/assets/icons/arrows/chevron_right.svg';
 
+import { small_500 } from '@/styles/commonStyle/localTextStyle';
+
 const CategoryBox = styled.ul`
   display: flex;
   align-items: center;
@@ -16,12 +18,7 @@ const CategoryList = styled.li`
   color: ${({ $isActiveCategory, theme: { colors } }) => {
     return $isActiveCategory ? colors.primary : colors.gray['60'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.sm;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${small_500}
   cursor: pointer;
 `;
 

--- a/src/components/PageNumber/index.jsx
+++ b/src/components/PageNumber/index.jsx
@@ -1,19 +1,21 @@
 import styled from 'styled-components';
-import { centerAlignStyle } from '@/styles/commonStyle/etc';
 
+import { centerAlignStyle } from '@/styles/commonStyle/etc';
 import { small_500 } from '@/styles/commonStyle/localTextStyle';
 
 const NumberBox = styled.li`
   ${centerAlignStyle}
   width: 30px;
   height: 30px;
-  color: ${({ $isMyNumber, $isActiveNumber, theme: { colors } }) => {
-    return $isMyNumber === $isActiveNumber ? colors.primary : colors.gray['70'];
+  color: ${({ $myPageNumber, $nowActiveNumber, theme: { colors } }) => {
+    return $myPageNumber === $nowActiveNumber
+      ? colors.primary
+      : colors.gray['70'];
   }};
   ${small_500}
   border: 1px solid
-    ${({ $isMyNumber, $isActiveNumber, theme: { colors } }) => {
-    return $isMyNumber === $isActiveNumber ? colors.primary : 'white';
+    ${({ $myPageNumber, $nowActiveNumber, theme: { colors } }) => {
+    return $myPageNumber === $nowActiveNumber ? colors.primary : 'white';
   }};
 
   border-radius: 4px;
@@ -22,17 +24,17 @@ const NumberBox = styled.li`
 `;
 
 export default function PageNumber({
-  myNumber,
-  activeNumber = 0,
-  onClick = null,
+  myPageNumber,
+  activePageNumber = 0,
+  handlePageNumberClick = null,
 }) {
   return (
     <NumberBox
-      onClick={onClick || null}
-      $isMyNumber={myNumber}
-      $isActiveNumber={activeNumber}
+      onClick={handlePageNumberClick || null}
+      $myPageNumber={myPageNumber}
+      $nowActiveNumber={activePageNumber}
     >
-      {myNumber + 1}
+      {myPageNumber + 1}
     </NumberBox>
   );
 }

--- a/src/components/PageNumber/index.jsx
+++ b/src/components/PageNumber/index.jsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 import { centerAlignStyle } from '@/styles/commonStyle/etc';
 
+import { small_500 } from '@/styles/commonStyle/localTextStyle';
+
 const NumberBox = styled.li`
   ${centerAlignStyle}
   width: 30px;
@@ -8,16 +10,11 @@ const NumberBox = styled.li`
   color: ${({ $isMyNumber, $isActiveNumber, theme: { colors } }) => {
     return $isMyNumber === $isActiveNumber ? colors.primary : colors.gray['70'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.sm;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${small_500}
   border: 1px solid
     ${({ $isMyNumber, $isActiveNumber, theme: { colors } }) => {
-      return $isMyNumber === $isActiveNumber ? colors.primary : 'white';
-    }};
+    return $isMyNumber === $isActiveNumber ? colors.primary : 'white';
+  }};
 
   border-radius: 4px;
   user-select: none;

--- a/src/components/Pagination/index.jsx
+++ b/src/components/Pagination/index.jsx
@@ -1,0 +1,57 @@
+import PageNumber from '@/components/PageNumber';
+
+import prevArrow from '@/assets/icons/arrows/chevron_left.svg';
+import nextArrow from '@/assets/icons/arrows/chevron_right.svg';
+import prev10PagesArrow from '@/assets/icons/arrows/double_chevron_lef.svg';
+import next10PagesArrow from '@/assets/icons/arrows/double_chevron_right.svg';
+
+import {
+  ArrowBox,
+  ArrowButton,
+  PageNumberBox,
+} from '@/components/Pagination/style';
+
+export default function Pagination({
+  pageNumberData,
+  activePageNumber = 0,
+  handlePrevPageButtonClick = null,
+  handlePrev10PageButtonClick = null,
+  handleNextPageButtonClick = null,
+  handleNext10PageButtonClick = null,
+  handlePageNumberClick = null,
+}) {
+  return (
+    <>
+      <ArrowBox>
+        <ArrowButton onClick={handlePrevPageButtonClick || null}>
+          <img src={prevArrow} alt={'prev-page-button'} />
+        </ArrowButton>
+        <ArrowButton onClick={handlePrev10PageButtonClick || null}>
+          <img src={prev10PagesArrow} alt={'prev-10pages-button'} />
+        </ArrowButton>
+      </ArrowBox>
+      <PageNumberBox>
+        {pageNumberData?.map((item, idx) => {
+          return (
+            <PageNumber
+              key={item + 'pageNumber'}
+              myPageNumber={idx}
+              activePageNumber={activePageNumber}
+              handlePageNumberClick={() => {
+                handlePageNumberClick(idx);
+              }}
+            />
+          );
+        })}
+      </PageNumberBox>
+      <ArrowBox>
+        <ArrowButton onClick={handleNextPageButtonClick || null}>
+          <img src={nextArrow} alt={'next-page-button'} />
+        </ArrowButton>
+        <ArrowButton onClick={handleNext10PageButtonClick || null}>
+          <img src={next10PagesArrow} alt={'next-10pages-button'} />
+        </ArrowButton>
+      </ArrowBox>
+    </>
+  );
+}

--- a/src/components/Pagination/style.js
+++ b/src/components/Pagination/style.js
@@ -2,6 +2,14 @@ import styled from 'styled-components';
 
 import { defaultBorderBoxStyle } from '@/styles/commonStyle/box';
 import { centerAlignStyle } from '@/styles/commonStyle/etc';
+import {
+  pageArrowWrapperStyle,
+  pageNumberWrapperStyle,
+} from '@/styles/commonStyle/wrapper';
+
+const ArrowBox = styled.div`
+  ${pageArrowWrapperStyle}
+`;
 
 const ArrowButton = styled.div`
   ${defaultBorderBoxStyle}
@@ -16,10 +24,8 @@ const ArrowButton = styled.div`
   }
 `;
 
-export default function PageControlArrow({ onClick = null, arrowImg, alt }) {
-  return (
-    <ArrowButton onClick={onClick || null}>
-      <img src={arrowImg} alt={alt} />
-    </ArrowButton>
-  );
-}
+const PageNumberBox = styled.ul`
+  ${pageNumberWrapperStyle}
+`;
+
+export { ArrowBox, ArrowButton, PageNumberBox };

--- a/src/components/PostList/style.js
+++ b/src/components/PostList/style.js
@@ -1,5 +1,7 @@
 import styled from 'styled-components';
 
+import { xsmall_500, xsmall_600 } from '@/styles/commonStyle/localTextStyle';
+
 export const PostWrapper = styled.li`
   display: flex;
   justify-content: space-between;
@@ -25,12 +27,7 @@ export const PostNumber = styled.p`
   color: ${({ theme: { colors } }) => {
     return colors.gray['80'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.xs;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.semiBold;
-  }};
+  ${xsmall_600}
 `;
 
 export const Category = styled.div`
@@ -72,11 +69,7 @@ export const Date = styled.p`
   color: ${({ theme: { colors } }) => {
     return colors.gray['60'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.xs;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
+  ${xsmall_500}
   }};
 `;
 

--- a/src/layouts/Navbar/style.js
+++ b/src/layouts/Navbar/style.js
@@ -1,23 +1,25 @@
 import { Link } from 'react-router-dom';
+
 import styled from 'styled-components';
+
+import { large_400 } from '@/styles/commonStyle/localTextStyle';
 
 export const Wrapper = styled.header`
   display: flex;
   margin: auto;
   height: 48px;
   width: 1128px;
-  border-bottom: 1px solid ${props => props.theme.colors.gray[40]};  
+  border-bottom: 1px solid ${(props) => props.theme.colors.gray[40]};
 `;
 
 export const Button = styled(Link)`
   margin-top: 13.5px;
-  font-size: ${props => props.theme.typo.size.lg};
-  font-weight: ${props => props.theme.typo.weight.regular};
-  color: ${props => props.theme.colors.primary};
+  color: ${(props) => props.theme.colors.primary};
+  ${large_400}
   cursor: pointer;
   margin-left: 7px;
   margin-right: 31px;
-  color: ${props => props.theme.colors.gray[70]};
+  color: ${(props) => props.theme.colors.gray[70]};
   display: flex;
   justify-content: center;
 `;

--- a/src/layouts/footer/style.js
+++ b/src/layouts/footer/style.js
@@ -46,7 +46,7 @@ export const DetailsWrapper = styled.div`
 export const Detail = styled.span`
   padding-left: 10px;
   padding-right: 10px;
-  font-size: 12px;
+  font-size: ${(props) => props.theme.typo.size.tiny};
   border-right: 1px solid black;
   color: black;
 
@@ -63,5 +63,7 @@ export const Copyright = styled.div`
   margin-top: 14px;
   margin-left: 10px;
   margin-right: 10px;
-  font-size: 12px;
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.tiny;
+  }};
 `;

--- a/src/pages/Community/CommunityPost/style.js
+++ b/src/pages/Community/CommunityPost/style.js
@@ -1,5 +1,11 @@
 import styled from 'styled-components';
+
 import { ellipsisStyle } from '@/styles/commonStyle/etc';
+import {
+  xsmall_400,
+  small_400,
+  small_500,
+} from '@/styles/commonStyle/localTextStyle';
 
 const PostContainer = styled.li`
   display: flex;
@@ -24,12 +30,7 @@ const PostNumberBox = styled.p`
   color: ${({ theme: { colors } }) => {
     return colors.gray['90'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.sm;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${small_500}
 `;
 const PostBodyBox = styled.div`
   display: flex;
@@ -43,21 +44,11 @@ const PostBodyBox = styled.div`
     }};
   }
   p:first-child {
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.xs;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.regular;
-    }};
+    ${xsmall_400}
     margin-bottom: 24px;
   }
   p:last-child {
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.sm;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.regular;
-    }};
+    ${small_400}
   }
 `;
 
@@ -80,12 +71,7 @@ const PostDateBox = styled.p`
   color: ${({ theme: { colors } }) => {
     return colors.gray['70'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.sm;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${small_500}
 `;
 
 export {

--- a/src/pages/Community/index.jsx
+++ b/src/pages/Community/index.jsx
@@ -1,17 +1,11 @@
 import { useState } from 'react';
 
+import CommunityPost from '@/pages/Community/CommunityPost';
 import CommunityBanner from '@/components/CommunityBanner';
 import CommunityBannerText from '@/components/CommunityBannerText';
-import CommunityPost from '@/pages/Community/CommunityPost';
-import PageControlArrow from '@/components/PageControlArrow';
-import PageNumber from '@/components/PageNumber';
+import Pagination from '@/components/Pagination';
 import AlignSelectMenu from '@/components/AlignSelectMenu';
 import brush from '@/assets/icons/etc/brush.svg';
-
-import prevArrow from '@/assets/icons/arrows/chevron_left.svg';
-import nextArrow from '@/assets/icons/arrows/chevron_right.svg';
-import prev10PagesArrow from '@/assets/icons/arrows/double_chevron_lef.svg';
-import next10PagesArrow from '@/assets/icons/arrows/double_chevron_right.svg';
 
 import {
   ContentsAlignBox,
@@ -19,8 +13,6 @@ import {
   PostWrapper,
   PostHeaderBox,
   PageWrapper,
-  ArrowBox,
-  PageNumberBox,
 } from '@/pages/Community/style';
 
 export default function Community() {
@@ -32,9 +24,7 @@ export default function Community() {
 
   const [tempPageNumber, setTempPageNumber] = useState(0);
   const handlePageClick = (idx) => {
-    return () => {
-      setTempPageNumber(idx);
-    };
+    setTempPageNumber(idx);
   };
   return (
     <>
@@ -68,32 +58,11 @@ export default function Community() {
         })}
       </ul>
       <PageWrapper>
-        <ArrowBox>
-          <PageControlArrow arrowImg={prevArrow} alt={'prev-button'} />
-          <PageControlArrow
-            arrowImg={prev10PagesArrow}
-            alt={'prev-10pages-button'}
-          />
-        </ArrowBox>
-        <PageNumberBox>
-          {tempData.map((item, idx) => {
-            return (
-              <PageNumber
-                key={item + 'pageNumber'}
-                myNumber={idx}
-                activeNumber={tempPageNumber}
-                onClick={handlePageClick(idx)}
-              />
-            );
-          })}
-        </PageNumberBox>
-        <ArrowBox>
-          <PageControlArrow arrowImg={nextArrow} alt={'next-button'} />
-          <PageControlArrow
-            arrowImg={next10PagesArrow}
-            alt={'next-10pages-button'}
-          />
-        </ArrowBox>
+        <Pagination
+          pageNumberData={tempData}
+          activePageNumber={tempPageNumber}
+          handlePageNumberClick={handlePageClick}
+        />
       </PageWrapper>
     </>
   );

--- a/src/pages/Community/style.js
+++ b/src/pages/Community/style.js
@@ -3,11 +3,7 @@ import { Link } from 'react-router-dom';
 
 import { primaryColorBoxStyle } from '@/styles/commonStyle/box';
 import { postsHeaderStyle, ellipsisStyle } from '@/styles/commonStyle/etc';
-import {
-  paginationWrapperStyle,
-  pageArrowWrapperStyle,
-  pageNumberWrapperStyle,
-} from '@/styles/commonStyle/wrapper';
+import { paginationWrapperStyle } from '@/styles/commonStyle/wrapper';
 import { small_500, small_600 } from '@/styles/commonStyle/localTextStyle';
 
 const ContentsAlignBox = styled.div`
@@ -68,20 +64,10 @@ const PageWrapper = styled.section`
   margin: 50px auto 95px;
 `;
 
-const ArrowBox = styled.div`
-  ${pageArrowWrapperStyle}
-`;
-
-const PageNumberBox = styled.ul`
-  ${pageNumberWrapperStyle}
-`;
-
 export {
   ContentsAlignBox,
   PostCreateButton,
   PostWrapper,
   PostHeaderBox,
   PageWrapper,
-  ArrowBox,
-  PageNumberBox,
 };

--- a/src/pages/Community/style.js
+++ b/src/pages/Community/style.js
@@ -8,6 +8,7 @@ import {
   pageArrowWrapperStyle,
   pageNumberWrapperStyle,
 } from '@/styles/commonStyle/wrapper';
+import { small_500, small_600 } from '@/styles/commonStyle/localTextStyle';
 
 const ContentsAlignBox = styled.div`
   display: flex;
@@ -25,9 +26,7 @@ const PostCreateButton = styled(Link)`
   width: 135px;
   height: 40px;
   padding: 5px 12px;
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.sm;
-  }};
+  ${small_600}
   > img {
     width: 24px;
     height: 24px;
@@ -60,12 +59,7 @@ const PostHeaderBox = styled.div`
     margin-right: 20px;
   }
   p {
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.sm;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.medium;
-    }};
+    ${small_500}
   }
 `;
 

--- a/src/pages/CreateCommunityPost/Buttons/index.jsx
+++ b/src/pages/CreateCommunityPost/Buttons/index.jsx
@@ -6,6 +6,7 @@ import {
   primaryBorderBoxStyle,
 } from '@/styles/commonStyle/box';
 import { centerAlignStyle } from '@/styles/commonStyle/etc';
+import { medium_400 } from '@/styles/commonStyle/localTextStyle';
 
 const CansleButton = styled(Link)`
   ${primaryBorderBoxStyle}
@@ -15,12 +16,7 @@ const CansleButton = styled(Link)`
   color: ${({ theme: { colors } }) => {
     return colors.primary;
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.md;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.regular;
-  }};
+  ${medium_400}
   cursor: pointer;
   user-select: none;
 `;
@@ -33,12 +29,7 @@ const SubmitButton = styled.button`
   color: ${({ theme: { colors } }) => {
     return colors.white;
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.md;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.regular;
-  }};
+  ${medium_400}
   cursor: pointer;
   user-select: none;
 `;

--- a/src/pages/CreateCommunityPost/CategoryTitle/index.jsx
+++ b/src/pages/CreateCommunityPost/CategoryTitle/index.jsx
@@ -1,24 +1,16 @@
 import styled from 'styled-components';
 
+import { xsmall_500, h4_500 } from '@/styles/commonStyle/localTextStyle';
+
 const Title = styled.h2`
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.h4;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${h4_500}
   margin-left: 30px;
 `;
 const Notice = styled.p`
   color: ${({ theme: { colors } }) => {
     return colors.black;
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.xs;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${xsmall_500}
   margin-right: 70px;
 `;
 

--- a/src/pages/CreateCommunityPost/HospitalSearchModal/style.js
+++ b/src/pages/CreateCommunityPost/HospitalSearchModal/style.js
@@ -1,5 +1,12 @@
 import styled from 'styled-components';
 
+import {
+  h3_600,
+  h4_400,
+  medium_600,
+  small_400,
+} from '@/styles/commonStyle/localTextStyle';
+
 const ModalWrapper = styled.div`
   display: flex;
   position: relative;
@@ -16,12 +23,7 @@ const ModalWrapper = styled.div`
 const ModalInnerLeftBox = styled.div`
   width: 620px;
   > h2 {
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.h3;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.semiBold;
-    }};
+    ${h3_600}
     margin-bottom: 35px;
   }
 `;
@@ -41,12 +43,7 @@ const SearchInputArea = styled.label`
     color: ${({ theme: { colors } }) => {
       return colors.gray['100'];
     }};
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.h4;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.regular;
-    }};
+    ${h4_400}
   }
   > img {
     width: 36px;
@@ -85,12 +82,7 @@ const HospitalName = styled.p`
   color: ${({ theme: { colors } }) => {
     return colors.gray['100'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.md;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.semiBold;
-  }};
+  ${medium_600}
   margin-bottom: 20px;
 `;
 
@@ -101,12 +93,7 @@ const HospitalLocationInfo = styled.div`
   color: ${({ theme: { colors } }) => {
     return colors.gray['100'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.sm;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.regular;
-  }};
+  ${small_400}
   margin-bottom: 20px;
   > p:first-child {
     color: ${({ theme: { colors } }) => {
@@ -124,12 +111,7 @@ const HospitalContact = styled.p`
   color: ${({ theme: { colors } }) => {
     return colors.gray['100'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.sm;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.regular;
-  }};
+  ${small_400}
 `;
 
 const ModalInnerRightBox = styled.div`

--- a/src/pages/CreateCommunityPost/style.js
+++ b/src/pages/CreateCommunityPost/style.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { defaultBorderBoxStyle } from '@/styles/commonStyle/box';
 import { createPostPageInputBoxStyle } from '@/styles/commonStyle/box';
 import { createPostPageInputStyle } from '@/styles/commonStyle/input';
+import { xsmall_500, small_400 } from '@/styles/commonStyle/localTextStyle';
 
 const CategoryBox = styled.section`
   margin: 60px 0 30px;
@@ -56,12 +57,7 @@ const DataInputBox = styled.div`
     color: ${({ theme: { colors } }) => {
       return colors.gray['90'];
     }};
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.xs;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.medium;
-    }};
+    ${xsmall_500}
     margin-right: 45px;
   }
 
@@ -97,6 +93,9 @@ const DataInputBox = styled.div`
     > input {
       width: 90%;
       font-size: inherit;
+      font-weight: ${({ theme: { typo } }) => {
+        return typo.weight.regular;
+      }};
       cursor: pointer;
     }
     > img {
@@ -112,6 +111,7 @@ const ButtonBox = styled.section`
   width: 510px;
   margin: 0 auto 175px;
 `;
+
 export {
   CategoryBox,
   CenterdContainer,

--- a/src/pages/Error/style.js
+++ b/src/pages/Error/style.js
@@ -1,6 +1,13 @@
-import styled from 'styled-components';
 import { Link } from 'react-router-dom';
+
+import styled from 'styled-components';
+
 import { primaryColorBoxStyle } from '@/styles/commonStyle/box';
+import {
+  h3_700,
+  medium_400,
+  medium_500,
+} from '@/styles/commonStyle/localTextStyle';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -18,15 +25,13 @@ export const Wrapper = styled.div`
   > h2 {
     margin-top: 343px;
     color: ${(props) => props.theme.colors.gray[100]};
-    font-size: ${(props) => props.theme.typo.size.h3};
-    font-weight: ${(props) => props.theme.typo.weight.bold};
+    ${h3_700}
     margin-bottom: 59px;
   }
 
   > h4 {
     color: ${(props) => props.theme.colors.gray[100]};
-    font-size: ${(props) => props.theme.typo.size.md};
-    font-weight: ${(props) => props.theme.typo.weight.medium};
+    ${medium_500}
     line-height: 24px;
   }
 `;
@@ -39,10 +44,5 @@ export const Button = styled(Link)`
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.md;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.regular;
-  }};
+  ${medium_400}
 `;

--- a/src/pages/Find/ID/Success/Modal/style.js
+++ b/src/pages/Find/ID/Success/Modal/style.js
@@ -2,6 +2,7 @@ import Close from '@/components/Icons/Close';
 import styled from 'styled-components';
 
 import { modalBoxStyle, primaryBorderBoxStyle } from '@/styles/commonStyle/box';
+import { h4_600, small_400 } from '@/styles/commonStyle/localTextStyle';
 
 export const ModalBox = styled.div`
   ${modalBoxStyle};
@@ -11,16 +12,14 @@ export const ModalBox = styled.div`
 
   > h4 {
     margin-top: 23px;
-    font-size: ${(props) => props.theme.typo.size.h4};
-    font-weight: ${(props) => props.theme.typo.weight.semiBold};
+    ${h4_600}
     color: ${(props) => props.theme.colors.highlight};
     margin-bottom: 16px;
   }
 
   > h6 {
     margin-top: 12px;
-    font-size: ${(props) => props.theme.typo.size.sm};
-    font-weight: ${(props) => props.theme.typo.weight.regular};
+    ${small_400}
     color: ${(props) => props.theme.colors.gray[100]};
   }
 `;

--- a/src/pages/Find/components/Active/index.jsx
+++ b/src/pages/Find/components/Active/index.jsx
@@ -1,22 +1,21 @@
-import { Link } from "react-router-dom";
-import styled from "styled-components";
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { medium_600 } from '@/styles/commonStyle/localTextStyle';
 
 const ActiveBox = styled(Link)`
   width: 254px;
-  border-bottom: 3px solid ${props => props.theme.colors.primary};
-  font-size: ${props => props.theme.typo.size.md};
-  font-weight: ${props => props.theme.typo.weight.semiBold};
-  color: ${props => props.theme.colors.primary};  
+  border-bottom: 3px solid ${(props) => props.theme.colors.primary};
+  ${medium_600}
+  color: ${(props) => props.theme.colors.primary};
   height: 33px;
   display: flex;
   justify-content: center;
   cursor: pointer;
 `;
 
-function Active({type, text}) {
-  return (
-    <ActiveBox to={`/find/${type}`}>{text}</ActiveBox>
-  );
+function Active({ type, text }) {
+  return <ActiveBox to={`/find/${type}`}>{text}</ActiveBox>;
 }
 
 export default Active;

--- a/src/pages/Find/components/Inactive/index.jsx
+++ b/src/pages/Find/components/Inactive/index.jsx
@@ -1,22 +1,21 @@
-import { Link } from "react-router-dom";
-import styled from "styled-components";
+import { Link } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { medium_600 } from '@/styles/commonStyle/localTextStyle';
 
 const InactiveBox = styled(Link)`
   width: 254px;
-  font-size: ${props => props.theme.typo.size.md};
-  font-weight: ${props => props.theme.typo.weight.semiBold};
-  color: ${props => props.theme.colors.gray[40]};  
-  border-bottom: 1px solid ${props => props.theme.colors.gray[40]};
+  ${medium_600}
+  color: ${(props) => props.theme.colors.gray[40]};
+  border-bottom: 1px solid ${(props) => props.theme.colors.gray[40]};
   display: flex;
   justify-content: center;
   height: 33px;
-  cursor: pointer;  
+  cursor: pointer;
 `;
 
-function Inactive({type, text}) {
-  return (
-    <InactiveBox to={`/find/${type}`}>{text}</InactiveBox>
-  );
+function Inactive({ type, text }) {
+  return <InactiveBox to={`/find/${type}`}>{text}</InactiveBox>;
 }
 
 export default Inactive;

--- a/src/pages/Find/components/Wrapper/style.js
+++ b/src/pages/Find/components/Wrapper/style.js
@@ -1,20 +1,20 @@
-import styled from "styled-components";
+import styled from 'styled-components';
+
+import { medium_400, small_400 } from '@/styles/commonStyle/localTextStyle';
 
 export const StyledWrapper = styled.div`
-  display:flex;
+  display: flex;
   align-items: center;
   flex-direction: column;
 
   > p {
-    font-size: ${props => props.theme.typo.size.md};
-    font-weight: ${props => props.theme.typo.weight.regular};
-    color: ${props => props.theme.colors.gray[100]};  
+    ${medium_400}
+    color: ${(props) => props.theme.colors.gray[100]};
   }
 
   > span {
-    font-size: ${props => props.theme.typo.size.sm};
-    font-weight: ${props => props.theme.typo.weight.regular};
-    color: ${props => props.theme.colors.gray[60]};
-    margin-top: 23px;  
+    ${small_400}
+    color: ${(props) => props.theme.colors.gray[60]};
+    margin-top: 23px;
   }
 `;

--- a/src/pages/Home/Link/style.js
+++ b/src/pages/Home/Link/style.js
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
 
+import { h4_400, h4_600 } from '@/styles/commonStyle/localTextStyle';
+
 export const Wrapper = styled.div`
   display: flex;
   margin: auto;
   align-items: center;
-  background-color: ${props => props.theme.colors.primary};
+  background-color: ${(props) => props.theme.colors.primary};
   height: 197px;
   width: 1128px;
   margin-top: 53px;
@@ -19,16 +21,14 @@ export const LeftWrapper = styled.div`
 `;
 
 export const Title = styled.span`
-  color: ${props => props.theme.colors.gray[10]};
-  font-size: ${props => props.theme.typo.size.h4};
-  font-weight: ${props => props.theme.typo.weight.regular};
+  color: ${(props) => props.theme.colors.gray[10]};
+  ${h4_400}
   letter-spacing: 0px;
-`
+`;
 export const Goto = styled.div`
   margin-top: 11px;
-  font-size: ${props => props.theme.typo.size.h4};
-  color: ${props => props.theme.colors.white};
-  font-weight: ${props => props.theme.typo.weight.semiBold};
+  color: ${(props) => props.theme.colors.white};
+  ${h4_600}
   display: flex;
   align-items: center;
 `;
@@ -38,8 +38,8 @@ export const ArrowIconWrapper = styled.div`
   align-items: center;
   justify-content: center;
   margin-left: 9px;
-  background-color: ${props => props.theme.colors.white};
-  opacity:0.45;
+  background-color: ${(props) => props.theme.colors.white};
+  opacity: 0.45;
   width: 30px;
   height: 30px;
   border-radius: 4px;

--- a/src/pages/Home/Post/style.js
+++ b/src/pages/Home/Post/style.js
@@ -1,5 +1,12 @@
 import styled from 'styled-components';
 
+import {
+  small_400,
+  small_600,
+  h4_600,
+  xsmall_500,
+  medium_400,
+} from '@/styles/commonStyle/localTextStyle';
 export const Wrapper = styled.div`
   margin: auto;
   margin-top: 52px;
@@ -14,20 +21,18 @@ export const UpperWrapper = styled.div`
   padding-left: 24px;
   padding-right: 6px;
   padding-bottom: 18px;
-  border-bottom: 1px solid ${props => props.theme.colors.gray[60]};
+  border-bottom: 1px solid ${(props) => props.theme.colors.gray[60]};
 `;
 
 export const UpperTitle = styled.span`
-  color: ${props => props.theme.colors.gray[90]};  
-  font-size: ${props => props.theme.typo.size.h4};
-  font-weight: ${props => props.theme.typo.weight.semiBold};
+  color: ${(props) => props.theme.colors.gray[90]};
+  ${h4_600}
 `;
 
 export const ShowMoreButton = styled.button`
-  font-size: ${props => props.theme.typo.size.sm};
-  font-weight: ${props => props.theme.typo.weight.semiBold};
   height: 28px;
-  color: ${props => props.theme.colors.gray[60]};
+  color: ${(props) => props.theme.colors.gray[60]};
+  ${small_600}
   cursor: pointer;
   border: none;
   margin-left: auto;
@@ -44,7 +49,7 @@ export const ShowMoreButtonIcon = styled.img`
 export const LowerWrapper = styled.div`
   width: 1128px;
   height: 330px;
-  border-top: 1px solid ${props => props.theme.colors.gray[60]};
+  border-top: 1px solid ${(props) => props.theme.colors.gray[60]};
 `;
 
 export const PostWrapper = styled.div`
@@ -57,46 +62,43 @@ export const PostWrapper = styled.div`
 `;
 
 export const CategoryButton = styled.button`
-  font-size: ${props => props.theme.typo.size.xs};
-  font-weight: ${props => props.theme.typo.weight.medium};
   height: 27px;
-  color: ${props => props.theme.colors.primary};
+  color: ${(props) => props.theme.colors.primary};
+  ${xsmall_500}
   border: none;
   display: flex;
   align-items: center;
   padding-left: 12px;
   padding-right: 12px;
   border-radius: 4px;
-  background-color: ${props => props.theme.colors.secondary};
+  background-color: ${(props) => props.theme.colors.secondary};
 `;
 
 export const PostTitle = styled.span`
-  color: ${props => props.theme.colors.gray[100]};  
-  font-size: ${props => props.theme.typo.size.md};
-  font-weight: ${props => props.theme.typo.weight.regular};
+  color: ${(props) => props.theme.colors.gray[100]};
+  ${medium_400}
   margin-left: 18px;
-  margin-right: auto;  
+  margin-right: auto;
 `;
 
 export const Comment = styled.span`
-  color: ${props => props.theme.colors.highlight};  
-  font-weight: ${props => props.theme.typo.weight.semiBold};
+  color: ${(props) => props.theme.colors.highlight};
+  font-weight: ${(props) => props.theme.typo.weight.semiBold};
 `;
 
 export const LowerIcon = styled.img`
   width: 24px;
   height: 24px;
   margin-right: 8px;
-`
+`;
 
 export const LowerDescription = styled.span`
-  color: ${props => props.theme.colors.gray[60]};  
-  font-size: ${props => props.theme.typo.size.sm};
-  font-weight: ${props => props.theme.typo.weight.regular};
-`
+  color: ${(props) => props.theme.colors.gray[60]};
+  ${small_400}
+`;
 
 export const LowerDescriptionWrapper = styled.div`
   margin-left: 20px;
   display: flex;
   align-items: center;
-`
+`;

--- a/src/pages/MyPage/PasswordChange/style.js
+++ b/src/pages/MyPage/PasswordChange/style.js
@@ -4,6 +4,11 @@ import {
   defaultBorderBoxStyle,
   primaryColorBoxStyle,
 } from '@/styles/commonStyle/box';
+import {
+  xsmall_500,
+  xsmall_600,
+  medium_400,
+} from '@/styles/commonStyle/localTextStyle';
 
 const PasswordChangeWrapper = styled.div`
   margin-top: 15px;
@@ -27,12 +32,7 @@ const PasswordChgngeBox = styled.section`
     color: ${({ theme: { colors } }) => {
       return colors.gray['80'];
     }};
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.xs;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.medium;
-    }};
+    ${xsmall_500}
   }
 `;
 
@@ -45,12 +45,7 @@ const InputBox = styled.label`
   height: 50px;
   > input {
     width: 90%;
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.xs;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.semiBold;
-    }};
+    ${xsmall_600}
   }
   > div {
     display: flex;
@@ -68,12 +63,7 @@ const NoticeMent = styled.p`
   color: ${({ theme: { colors } }) => {
     return colors.gray['60'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.xs;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${xsmall_500}
 `;
 
 const EditSaveBox = styled.section`
@@ -82,12 +72,7 @@ const EditSaveBox = styled.section`
     ${primaryColorBoxStyle}
     height: 50px;
     padding: 10px 35px;
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.md;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.regular;
-    }};
+    ${medium_400}
   }
 `;
 

--- a/src/pages/MyPage/PersonalInfo/style.js
+++ b/src/pages/MyPage/PersonalInfo/style.js
@@ -4,6 +4,11 @@ import {
   primaryBorderBoxStyle,
   primaryColorBoxStyle,
 } from '@/styles/commonStyle/box';
+import {
+  xsmall_500,
+  small_600,
+  medium_400,
+} from '@/styles/commonStyle/localTextStyle';
 
 const PersonalInfoWrapper = styled.div`
   margin-top: 15px;
@@ -26,23 +31,13 @@ const PersonalInfoBox = styled.div`
     color: ${({ theme: { colors } }) => {
       return colors.gray['80'];
     }};
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.xs;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.medium;
-    }};
+    ${xsmall_500}
   }
   >p: last-child {
     color: ${({ theme: { colors } }) => {
       return colors.gray['100'];
     }};
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.sm;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.semiBold;
-    }};
+    ${small_600}
   }
 `;
 
@@ -54,16 +49,11 @@ const NicknameEditBox = styled(PersonalInfoBox)`
       width: 200px;
       padding: 0 5px 8px 5px;
       margin-right: 15px;
-      font-size: ${({ theme: { typo } }) => {
-        return typo.size.sm;
-      }};
-      font-weight: ${({ theme: { typo } }) => {
-        return typo.weight.semiBold;
-      }};
+      ${small_600}
       border-bottom: 1px solid
         ${({ theme: { colors } }) => {
-          return colors.gray['40'];
-        }};
+        return colors.gray['40'];
+      }};
     }
     > button {
       ${primaryBorderBoxStyle}
@@ -88,12 +78,7 @@ const EditSaveAndAccountDeleteBox = styled.section`
   >button: first-child {
     ${primaryColorBoxStyle}
     padding: 10px 70px;
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.md;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.regular;
-    }};
+    ${medium_400}
   }
   >button: last-child {
     border-bottom: 1px solid
@@ -103,12 +88,7 @@ const EditSaveAndAccountDeleteBox = styled.section`
     color: ${({ theme: { colors } }) => {
       return colors.gray['90'];
     }};
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.xs;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.medium;
-    }};
+    ${xsmall_500}
   }
 `;
 export {

--- a/src/pages/MyPage/PostContents/index.jsx
+++ b/src/pages/MyPage/PostContents/index.jsx
@@ -1,13 +1,5 @@
-import { useState } from 'react';
-
 import PostList from '@/components/PostList';
-import PageControlArrow from '@/components/PageControlArrow';
-import PageNumber from '@/components/PageNumber';
-
-import prevArrow from '@/assets/icons/arrows/chevron_left.svg';
-import nextArrow from '@/assets/icons/arrows/chevron_right.svg';
-import prev10PagesArrow from '@/assets/icons/arrows/double_chevron_lef.svg';
-import next10PagesArrow from '@/assets/icons/arrows/double_chevron_right.svg';
+import Pagination from '@/components/Pagination';
 
 import {
   PostsWrapper,
@@ -16,24 +8,17 @@ import {
   PostsHeaderRightBox,
   PostListBox,
   PageWrapper,
-  ArrowBox,
-  PageNumberBox,
 } from '@/pages/MyPage/PostContents/style';
 
 export default function PostContents({
-  pageData,
   postData,
   pageName,
   scrapViewState = false,
   scrapClickState = false,
+  pageNumberData,
+  activePageNumber = 0,
+  handlePageNumberClick = null,
 }) {
-  const [tempPageNumber, setTempPageNumber] = useState(0);
-  const handlePageClick = (idx) => {
-    return () => {
-      setTempPageNumber(idx);
-    };
-  };
-
   return (
     <PostsWrapper>
       <PostsHeader>
@@ -78,32 +63,11 @@ export default function PostContents({
           })}
       </PostListBox>
       <PageWrapper>
-        <ArrowBox>
-          <PageControlArrow arrowImg={prevArrow} alt={'prev-button'} />
-          <PageControlArrow
-            arrowImg={prev10PagesArrow}
-            alt={'prev-10pages-button'}
-          />
-        </ArrowBox>
-        <PageNumberBox>
-          {pageData.map((item, idx) => {
-            return (
-              <PageNumber
-                key={item + 'pageNumber'}
-                myNumber={idx}
-                activeNumber={tempPageNumber}
-                onClick={handlePageClick(idx)}
-              />
-            );
-          })}
-        </PageNumberBox>
-        <ArrowBox>
-          <PageControlArrow arrowImg={nextArrow} alt={'next-button'} />
-          <PageControlArrow
-            arrowImg={next10PagesArrow}
-            alt={'next-10pages-button'}
-          />
-        </ArrowBox>
+        <Pagination
+          pageNumberData={pageNumberData}
+          activePageNumber={activePageNumber}
+          handlePageNumberClick={handlePageNumberClick}
+        />
       </PageWrapper>
     </PostsWrapper>
   );

--- a/src/pages/MyPage/PostContents/style.js
+++ b/src/pages/MyPage/PostContents/style.js
@@ -6,6 +6,7 @@ import {
   pageArrowWrapperStyle,
   pageNumberWrapperStyle,
 } from '@/styles/commonStyle/wrapper';
+import { xsmall_500 } from '@/styles/commonStyle/localTextStyle';
 
 const PostsWrapper = styled.div`
   margin-top: 10px;
@@ -18,12 +19,7 @@ const PostsHeader = styled.div`
   padding: 12px 0;
 
   p {
-    font-size: ${({ theme: { typo } }) => {
-      return typo.size.xs;
-    }};
-    font-weight: ${({ theme: { typo } }) => {
-      return typo.weight.medium;
-    }};
+    ${xsmall_500}
   }
 `;
 

--- a/src/pages/MyPage/PostContents/style.js
+++ b/src/pages/MyPage/PostContents/style.js
@@ -1,11 +1,7 @@
 import styled from 'styled-components';
 
 import { postsHeaderStyle } from '@/styles/commonStyle/etc';
-import {
-  paginationWrapperStyle,
-  pageArrowWrapperStyle,
-  pageNumberWrapperStyle,
-} from '@/styles/commonStyle/wrapper';
+import { paginationWrapperStyle } from '@/styles/commonStyle/wrapper';
 import { xsmall_500 } from '@/styles/commonStyle/localTextStyle';
 
 const PostsWrapper = styled.div`
@@ -53,14 +49,6 @@ const PageWrapper = styled.section`
   margin: 50px auto 130px;
 `;
 
-const ArrowBox = styled.div`
-  ${pageArrowWrapperStyle}
-`;
-
-const PageNumberBox = styled.ul`
-  ${pageNumberWrapperStyle}
-`;
-
 export {
   PostsWrapper,
   PostsHeader,
@@ -68,6 +56,4 @@ export {
   PostsHeaderRightBox,
   PostListBox,
   PageWrapper,
-  ArrowBox,
-  PageNumberBox,
 };

--- a/src/pages/MyPage/SideTabMenu/index.jsx
+++ b/src/pages/MyPage/SideTabMenu/index.jsx
@@ -1,15 +1,12 @@
 import styled from 'styled-components';
 
+import { xsmall_500, xsmall_600 } from '@/styles/commonStyle/localTextStyle';
+
 const SideTabTitle = styled.h2`
   color: ${({ theme: { colors } }) => {
     return colors.gray['100'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.xs;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.semiBold;
-  }};
+  ${xsmall_600}
   padding-bottom: 10px;
   border-bottom: 1px solid
     ${({ theme: { colors } }) => {
@@ -27,12 +24,7 @@ const SideTabMenuList = styled.li`
   color: ${({ $isActiveMenu, $isContent, theme: { colors } }) => {
     return $isActiveMenu === $isContent ? colors.primary : colors.gray['50'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.xs;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${xsmall_500}
   margin-bottom: 15px;
   &:last-child {
     margin-bottom: 35px;

--- a/src/pages/MyPage/index.jsx
+++ b/src/pages/MyPage/index.jsx
@@ -36,6 +36,12 @@ export default function MyPage() {
       return index;
     })
   );
+
+  const [tempPageNumber, setTempPageNumber] = useState(0);
+  const handlePageClick = (idx) => {
+    setTempPageNumber(idx);
+  };
+
   return (
     <>
       <Title>마이페이지</Title>
@@ -84,9 +90,11 @@ export default function MyPage() {
               </ActiveTabTitleBox>
               <PostContents
                 postData={postData}
-                pageData={pageData}
                 pageName={'my-page'}
                 scrapViewState={false}
+                activePageNumber={tempPageNumber}
+                pageNumberData={pageData}
+                handlePageNumberClick={handlePageClick}
               />
             </>
           )}
@@ -101,10 +109,12 @@ export default function MyPage() {
               </ActiveTabTitleBox>
               <PostContents
                 postData={postData}
-                pageData={pageData}
                 pageName={'my-page'}
                 scrapViewState={true}
                 scrapClickState={true}
+                activePageNumber={tempPageNumber}
+                pageNumberData={pageData}
+                handlePageNumberClick={handlePageClick}
               />
             </>
           )}
@@ -119,9 +129,11 @@ export default function MyPage() {
               </ActiveTabTitleBox>
               <PostContents
                 postData={postData}
-                pageData={pageData}
                 pageName={'my-page'}
                 scrapViewState={false}
+                activePageNumber={tempPageNumber}
+                pageNumberData={pageData}
+                handlePageNumberClick={handlePageClick}
               />
             </>
           )}

--- a/src/pages/MyPage/style.js
+++ b/src/pages/MyPage/style.js
@@ -1,14 +1,10 @@
 import styled from 'styled-components';
 
 import { defaultBorderBoxStyle } from '@/styles/commonStyle/box';
+import { h4_600, medium_600 } from '@/styles/commonStyle/localTextStyle';
 
 const Title = styled.h2`
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.h4;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.semiBold;
-  }};
+  ${h4_600}
   margin: 70px 0 30px;
   padding-left: 10px;
 `;
@@ -40,24 +36,14 @@ const ActiveTabTitleBox = styled.section`
       color: ${({ theme: { colors } }) => {
         return colors.gray['80'];
       }};
-      font-size: ${({ theme: { typo } }) => {
-        return typo.size.md;
-      }};
-      font-weight: ${({ theme: { typo } }) => {
-        return typo.weight.semiBold;
-      }};
+      ${medium_600}
       margin-left: 15px;
     }
   }
 `;
 
 const ActiveTabTitle = styled.h2`
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.h4;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.semiBold;
-  }};
+  ${h4_600}
 `;
 
 export {

--- a/src/pages/SignIn/Buttons/Modal/style.js
+++ b/src/pages/SignIn/Buttons/Modal/style.js
@@ -2,6 +2,12 @@ import Close from '@/components/Icons/Close';
 import styled from 'styled-components';
 
 import { modalBoxStyle, primaryBorderBoxStyle } from '@/styles/commonStyle/box';
+import {
+  xsmall_500,
+  xsmall_600,
+  small_400,
+  h4_600,
+} from '@/styles/commonStyle/localTextStyle';
 
 export const ModalBox = styled.div`
   ${modalBoxStyle};
@@ -11,30 +17,26 @@ export const ModalBox = styled.div`
 
   > h4 {
     margin-top: 23px;
-    font-size: ${(props) => props.theme.typo.size.h4};
-    font-weight: ${(props) => props.theme.typo.weight.semiBold};
+    ${h4_600}
     color: ${(props) => props.theme.colors.primary};
     margin-bottom: 16px;
   }
 
   > h6 {
     margin-top: 12px;
-    font-size: ${(props) => props.theme.typo.size.sm};
-    font-weight: ${(props) => props.theme.typo.weight.regular};
+    ${small_400}
     color: ${(props) => props.theme.colors.gray[100]};
   }
 
   > p {
     margin-top: 41px;
-    font-size: ${(props) => props.theme.typo.size.xs};
-    font-weight: ${(props) => props.theme.typo.weight.medium};
+    ${xsmall_500}
     color: ${(props) => props.theme.colors.gray[70]};
   }
 
   > span {
     margin-top: 21px;
-    font-size: ${(props) => props.theme.typo.size.xs};
-    font-weight: ${(props) => props.theme.typo.weight.semiBold};
+    ${xsmall_600}
     color: ${(props) => props.theme.colors.highlight};
   }
 `;

--- a/src/pages/SignIn/Buttons/style.js
+++ b/src/pages/SignIn/Buttons/style.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import { Link } from 'react-router-dom';
 import { instructionTextStyle } from '@/styles/commonStyle/text';
+import { xsmall_500 } from '@/styles/commonStyle/localTextStyle';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -31,16 +32,14 @@ export const CheckBox = styled.input`
 
 export const Description = styled.span`
   color: ${(props) => props.theme.colors.gray[70]};
-  font-size: ${(props) => props.theme.typo.size.xs};
-  font-weight: ${(props) => props.theme.typo.weight.medium};
+  ${xsmall_500}
 `;
 
 export const FindButton = styled(Link)`
   cursor: pointer;
   margin-left: auto;
   color: ${(props) => props.theme.colors.gray[70]};
-  font-size: ${(props) => props.theme.typo.size.xs};
-  font-weight: ${(props) => props.theme.typo.weight.medium};
+  ${xsmall_500}
 
   &:hover {
     color: ${(props) => props.theme.colors.primary};

--- a/src/pages/SignIn/Title/style.js
+++ b/src/pages/SignIn/Title/style.js
@@ -1,13 +1,13 @@
 import styled from 'styled-components';
 
 export const Wrapper = styled.div`
-		display: flex;
-		justify-content: center;
-		margin-top: 100px;
+  display: flex;
+  justify-content: center;
+  margin-top: 100px;
 `;
 
 export const Font = styled.span`
   font-size: 28px;
-	 font-weight: ${props => props.theme.typo.weight.semiBold};
-  color: ${props => props.theme.colors.primary};
+  font-weight: ${(props) => props.theme.typo.weight.semiBold};
+  color: ${(props) => props.theme.colors.primary};
 `;

--- a/src/pages/SignUp/Department/Inputs/Document/style.js
+++ b/src/pages/SignUp/Department/Inputs/Document/style.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 
 import { defaultBorderBoxStyle } from '@/styles/commonStyle/box';
 import { placeholderTextStyle } from '@/styles/commonStyle/text';
+import { small_400 } from '@/styles/commonStyle/localTextStyle';
 
 export const InactiveInputBox = styled.div`
   ${defaultBorderBoxStyle};
@@ -21,8 +22,7 @@ export const InactiveInputBox = styled.div`
 
 export const ActiveInputBox = styled.div`
   ${defaultBorderBoxStyle};
-  font-size: ${(props) => props.theme.typo.size.sm};
-  font-weight: ${(props) => props.theme.typo.weight.regular};
+  ${small_400}
   color: ${(props) => props.theme.colors.primary};
   width: 448px;
   height: 48px;

--- a/src/pages/SignUp/Identity/Agree/Modal/style.js
+++ b/src/pages/SignUp/Identity/Agree/Modal/style.js
@@ -3,6 +3,13 @@ import styled from 'styled-components';
 
 import { centerAlignStyle } from '@/styles/commonStyle/etc';
 import { modalBoxStyle, primaryBorderBoxStyle } from '@/styles/commonStyle/box';
+import {
+  small_400,
+  small_700,
+  medium_400,
+  large_700,
+  h3_700,
+} from '@/styles/commonStyle/localTextStyle';
 
 export const ModalBox = styled.div`
   ${modalBoxStyle};
@@ -22,8 +29,7 @@ export const Header = styled.div`
 
   > h3 {
     color: ${(props) => props.theme.colors.black};
-    font-size: ${(props) => props.theme.typo.size.h3};
-    font-weight: ${(props) => props.theme.typo.weight.bold};
+    ${h3_700}
   }
 `;
 
@@ -45,8 +51,7 @@ export const Body = styled.div`
 
   > h4 {
     color: ${(props) => props.theme.colors.black};
-    font-size: ${(props) => props.theme.typo.size.lg};
-    font-weight: ${(props) => props.theme.typo.weight.bold};
+    ${large_700}
     margin-top: 41px;
     margin-left: 40px;
   }
@@ -59,15 +64,13 @@ export const Body = styled.div`
 
     > h5 {
       color: ${(props) => props.theme.colors.black};
-      font-size: ${(props) => props.theme.typo.size.sm};
-      font-weight: ${(props) => props.theme.typo.weight.bold};
+      ${small_700}
       margin-bottom: 20px;
     }
 
     > p {
       color: ${(props) => props.theme.colors.gray[30]};
-      font-size: ${(props) => props.theme.typo.size.sm};
-      font-weight: ${(props) => props.theme.typo.weight.regular};
+      ${small_400}
       line-height: 24px;
     }
   }
@@ -91,12 +94,11 @@ export const Footer = styled.div`
 `;
 
 export const ActiveButton = styled.button`
+  display: flex;
   ${primaryBorderBoxStyle};
   width: 360px;
   height: 48px;
-  font-size: ${(props) => props.theme.typo.size.md};
-  font-weight: ${(props) => props.theme.typo.weight.regular};
-  display: flex;
+  ${medium_400}
   align-items: center;
   justify-content: center;
 `;

--- a/src/pages/SignUp/Identity/Agree/style.js
+++ b/src/pages/SignUp/Identity/Agree/style.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { instructionTextStyle } from '@/styles/commonStyle/text';
+import { small_400, small_600 } from '@/styles/commonStyle/localTextStyle';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -26,15 +27,13 @@ export const AgreeWrapper = styled.div`
 
   span {
     color: ${(props) => props.theme.colors.gray[100]};
-    font-size: ${(props) => props.theme.typo.size.sm};
-    font-weight: ${(props) => props.theme.typo.weight.regular};
+    ${small_400}
     margin-right: 10px;
   }
 
   p {
     color: ${(props) => props.theme.colors.gray[100]};
-    font-size: ${(props) => props.theme.typo.size.sm};
-    font-weight: ${(props) => props.theme.typo.weight.semiBold};
+    ${small_600}
   }
 `;
 export const Info = styled.span`

--- a/src/pages/SignUp/Identity/Inputs/PhoneNumber/style.js
+++ b/src/pages/SignUp/Identity/Inputs/PhoneNumber/style.js
@@ -8,6 +8,7 @@ import {
   primaryColorBoxStyle,
 } from '@/styles/commonStyle/box';
 import { placeholderTextStyle } from '@/styles/commonStyle/text';
+import { xsmall_500 } from '@/styles/commonStyle/localTextStyle';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -45,8 +46,7 @@ export const Button = styled.button`
   width: 112px;
   height: 48px;
   margin-top: 10px;
-  font-size: ${(props) => props.theme.typo.size.xs};
-  font-weight: ${(props) => props.theme.typo.weight.medium};
+  ${xsmall_500}
   margin-left: 11px;
 `;
 export const ActiveButton = styled(Button)`

--- a/src/pages/SignUp/Identity/Inputs/VerifyNumber/style.js
+++ b/src/pages/SignUp/Identity/Inputs/VerifyNumber/style.js
@@ -8,6 +8,7 @@ import {
   primaryColorBoxStyle,
 } from '@/styles/commonStyle/box';
 import { placeholderTextStyle } from '@/styles/commonStyle/text';
+import { xsmall_500 } from '@/styles/commonStyle/localTextStyle';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -31,9 +32,8 @@ export const SectionWrapper = styled.div`
   margin-top: 37px;
 `;
 export const Info = styled.span`
-  font-size: ${(props) => props.theme.typo.size.xs};
-  font-weight: ${(props) => props.theme.typo.weight.medium};
   color: #9b9b9b;
+  ${xsmall_500}
 `;
 
 export const InputWrapper = styled.form`
@@ -49,10 +49,10 @@ export const Button = styled.button`
   width: 96px;
   height: 48px;
   margin-top: 10px;
-  font-size: ${(props) => props.theme.typo.size.xs};
-  font-weight: ${(props) => props.theme.typo.weight.medium};
+  ${xsmall_500}
   margin-left: 10px;
 `;
+
 export const ActiveButton = styled(Button)`
   ${primaryColorBoxStyle};
 `;

--- a/src/pages/SignUp/Success/Modal/style.js
+++ b/src/pages/SignUp/Success/Modal/style.js
@@ -2,6 +2,12 @@ import Close from '@/components/Icons/Close';
 import styled from 'styled-components';
 
 import { modalBoxStyle } from '@/styles/commonStyle/box';
+import {
+  xsmall_500,
+  xsmall_600,
+  small_400,
+  h4_600,
+} from '@/styles/commonStyle/localTextStyle';
 
 export const ModalBox = styled.div`
   ${modalBoxStyle};
@@ -11,30 +17,26 @@ export const ModalBox = styled.div`
 
   > h4 {
     margin-top: 23px;
-    font-size: ${(props) => props.theme.typo.size.h4};
-    font-weight: ${(props) => props.theme.typo.weight.semiBold};
+    ${h4_600}
     color: ${(props) => props.theme.colors.primary};
     margin-bottom: 16px;
   }
 
   > h6 {
     margin-top: 12px;
-    font-size: ${(props) => props.theme.typo.size.sm};
-    font-weight: ${(props) => props.theme.typo.weight.regular};
+    ${small_400}
     color: ${(props) => props.theme.colors.gray[100]};
   }
 
   > p {
     margin-top: 41px;
-    font-size: ${(props) => props.theme.typo.size.xs};
-    font-weight: ${(props) => props.theme.typo.weight.medium};
+    ${xsmall_500}
     color: ${(props) => props.theme.colors.gray[70]};
   }
 
   > span {
     margin-top: 21px;
-    font-size: ${(props) => props.theme.typo.size.xs};
-    font-weight: ${(props) => props.theme.typo.weight.semiBold};
+    ${xsmall_600}
     color: ${(props) => props.theme.colors.highlight};
   }
 `;

--- a/src/pages/SignUp/Success/style.js
+++ b/src/pages/SignUp/Success/style.js
@@ -6,6 +6,7 @@ import {
   primaryBorderBoxStyle,
   primaryColorBoxStyle,
 } from '@/styles/commonStyle/box';
+import { small_400, h3_600 } from '@/styles/commonStyle/localTextStyle';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -13,9 +14,8 @@ export const Wrapper = styled.div`
   flex-direction: column;
 
   > h3 {
-    font-weight: ${(props) => props.theme.typo.weight.semiBold};
-    font-size: ${(props) => props.theme.typo.size.h3};
     color: ${(props) => props.theme.colors.gray[100]};
+    ${h3_600}
     margin-top: 31px;
   }
 
@@ -32,9 +32,8 @@ export const Wrapper = styled.div`
   }
 
   > span {
-    font-size: ${(props) => props.theme.typo.size.sm};
-    font-weight: ${(props) => props.theme.typo.weight.regular};
     color: ${(props) => props.theme.colors.gray[60]};
+    ${small_400}
     margin-top: 38px;
   }
 `;

--- a/src/pages/SignUp/components/Icons/style.js
+++ b/src/pages/SignUp/components/Icons/style.js
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 import { instructionTextStyle } from '@/styles/commonStyle/text';
+import { xsmall_600 } from '@/styles/commonStyle/localTextStyle';
 
 export const Wrapper = styled.div`
   display: flex;
@@ -40,9 +41,8 @@ export const FontWrapper = styled.div`
 `;
 
 export const FontActive = styled.span`
-  font-size: ${(props) => props.theme.typo.size.xs};
-  font-weight: ${(props) => props.theme.typo.weight.semiBold};
   color: ${(props) => props.theme.colors.primary};
+  ${xsmall_600}
   margin-top: 8px;
 `;
 

--- a/src/styles/commonStyle/box.js
+++ b/src/styles/commonStyle/box.js
@@ -1,5 +1,7 @@
 import { css } from 'styled-components';
 
+import { medium_600 } from '@/styles/commonStyle/localTextStyle';
+
 const defaultBorderBoxStyle = css`
   border: 1px solid
     ${({ theme: { colors } }) => {
@@ -54,8 +56,7 @@ const createPostPageInputBoxStyle = css`
 
 const authEmailColorBoxStyle = css`
   background-color: ${(props) => props.theme.colors.gray[10]};
-  font-size: ${(props) => props.theme.typo.size.md};
-  font-weight: ${(props) => props.theme.typo.weight.semiBold};
+  ${medium_600}
   color: ${(props) => props.theme.colors.primary};
   width: 336px;
   height: 58px;

--- a/src/styles/commonStyle/localTextStyle.js
+++ b/src/styles/commonStyle/localTextStyle.js
@@ -1,0 +1,164 @@
+import { css } from 'styled-components';
+
+const body = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.sm;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.regular;
+  }};
+`;
+
+const caption = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.tiny;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semibold;
+  }};
+`;
+
+const xsmall_500 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.xs;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.medium;
+  }};
+`;
+
+const xsmall_600 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.xs;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semoBold;
+  }};
+`;
+
+const xsmall_700 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.xs;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.bold;
+  }};
+`;
+
+const small_400 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.sm;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.regular;
+  }};
+`;
+
+const small_600 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.sm;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semoBold;
+  }};
+`;
+
+const medium_400 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.md;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.regular;
+  }};
+`;
+
+const medium_600 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.md;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semoBold;
+  }};
+`;
+
+const large_400 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.lg;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.regular;
+  }};
+`;
+
+const large_600 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.lg;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semoBold;
+  }};
+`;
+
+const h4_400 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.h4;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.regular;
+  }};
+`;
+
+const h4_600 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.h4;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semoBold;
+  }};
+`;
+
+const h3_600 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.h3;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semoBold;
+  }};
+`;
+
+const h2_600 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.h2;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semoBold;
+  }};
+`;
+
+const h1_600 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.h1;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.semoBold;
+  }};
+`;
+
+export {
+  body,
+  caption,
+  xsmall_500,
+  xsmall_600,
+  xsmall_700,
+  small_400,
+  small_600,
+  medium_400,
+  medium_600,
+  large_400,
+  large_600,
+  h4_400,
+  h4_600,
+  h3_600,
+  h2_600,
+  h1_600,
+};

--- a/src/styles/commonStyle/localTextStyle.js
+++ b/src/styles/commonStyle/localTextStyle.js
@@ -224,6 +224,7 @@ export {
   small_400,
   small_500,
   small_600,
+  small_700,
   medium_400,
   medium_500,
   medium_600,

--- a/src/styles/commonStyle/localTextStyle.js
+++ b/src/styles/commonStyle/localTextStyle.js
@@ -18,6 +18,15 @@ const caption = css`
   }};
 `;
 
+const xsmall_400 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.xs;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.regular;
+  }};
+`;
+
 const xsmall_500 = css`
   font-size: ${({ theme: { typo } }) => {
     return typo.size.xs;
@@ -54,6 +63,15 @@ const small_400 = css`
   }};
 `;
 
+const small_500 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.sm;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.medium;
+  }};
+`;
+
 const small_600 = css`
   font-size: ${({ theme: { typo } }) => {
     return typo.size.sm;
@@ -63,12 +81,30 @@ const small_600 = css`
   }};
 `;
 
+const small_700 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.sm;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.bold;
+  }};
+`;
+
 const medium_400 = css`
   font-size: ${({ theme: { typo } }) => {
     return typo.size.md;
   }};
   font-weight: ${({ theme: { typo } }) => {
     return typo.weight.regular;
+  }};
+`;
+
+const medium_500 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.md;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.medium;
   }};
 `;
 
@@ -90,6 +126,15 @@ const large_400 = css`
   }};
 `;
 
+const large_500 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.lg;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.medium;
+  }};
+`;
+
 const large_600 = css`
   font-size: ${({ theme: { typo } }) => {
     return typo.size.lg;
@@ -99,12 +144,29 @@ const large_600 = css`
   }};
 `;
 
+const large_700 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.lg;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.bold;
+  }};
+`;
+
 const h4_400 = css`
   font-size: ${({ theme: { typo } }) => {
     return typo.size.h4;
   }};
   font-weight: ${({ theme: { typo } }) => {
     return typo.weight.regular;
+  }};
+`;
+const h4_500 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.h4;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.medium;
   }};
 `;
 
@@ -123,6 +185,14 @@ const h3_600 = css`
   }};
   font-weight: ${({ theme: { typo } }) => {
     return typo.weight.semoBold;
+  }};
+`;
+const h3_700 = css`
+  font-size: ${({ theme: { typo } }) => {
+    return typo.size.h3;
+  }};
+  font-weight: ${({ theme: { typo } }) => {
+    return typo.weight.bold;
   }};
 `;
 
@@ -147,18 +217,25 @@ const h1_600 = css`
 export {
   body,
   caption,
+  xsmall_400,
   xsmall_500,
   xsmall_600,
   xsmall_700,
   small_400,
+  small_500,
   small_600,
   medium_400,
+  medium_500,
   medium_600,
   large_400,
+  large_500,
   large_600,
+  large_700,
   h4_400,
+  h4_500,
   h4_600,
   h3_600,
+  h3_700,
   h2_600,
   h1_600,
 };

--- a/src/styles/commonStyle/text.js
+++ b/src/styles/commonStyle/text.js
@@ -1,63 +1,49 @@
 import { css } from 'styled-components';
 
+import {
+  xsmall_500,
+  small_400,
+  large_400,
+  h4_600,
+  h3_600,
+} from '@/styles/commonStyle/localTextStyle';
+
 const bannerTitleStyle = css`
   color: ${({ theme: { colors } }) => {
     return colors.black;
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.h4;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.semiBold;
-  }};
+  ${h4_600}
 `;
 
 const bannerTextStyle = css`
   color: ${({ theme: { colors } }) => {
     return colors.gray['60'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.lg;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.regular;
-  }};
+  ${large_400}
 `;
 
 const instructionTextStyle = css`
   color: ${({ theme: { colors } }) => {
     return colors.gray['60'];
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.xs;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.medium;
-  }};
+  ${xsmall_500}
 `;
 
 const authTitleTextStyle = css`
   color: ${({ theme: { colors } }) => {
     return colors.gray.primary;
   }};
-  font-size: ${({ theme: { typo } }) => {
-    return typo.size.h3;
-  }};
-  font-weight: ${({ theme: { typo } }) => {
-    return typo.weight.semiBold;
-  }};
+  ${h3_600}
 `;
 
 const placeholderTextStyle = css`
-  font-size: ${(props) => props.theme.typo.size.sm};
-  font-weight: ${(props) => props.theme.typo.weight.regular};
   color: ${(props) => props.theme.colors.gray[40]};
+  ${small_400}
 `;
 
 const authDefaultTextStyle = css`
-  font-size: ${(props) => props.theme.typo.size.sm};
-  font-weight: ${(props) => props.theme.typo.weight.regular};
   color: ${(props) => props.theme.colors.gray[100]};
+  ${small_400}
 `;
 
 export {


### PR DESCRIPTION
## PR 유형

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제


## 작업내용
1. 피그마에 로컬스타일에 정의된 스타일 네이밍 대로 묶음 단위 폰트 스타일을 정의 하였습니다.
이제 일일이 폰트 세부정보를 확인하지 않아도 됩니다. 피그마에 써져있는 네이밍 보고 그대로 import 하시면 됩니다.

 2. 쓸데없이 나뉘어져있던 페이지 컴포넌트를 하나로 통합하고 전체적으로 리팩토링을 진행하였습니다.

## 요약 (필수작성 X)


## 참고사항
merge하게 되면 현재까지 size,weight 분할하여 작성하신 (ex font-size: md, font-weight: medium) 스타일을 묶음 단위 폰트 스타일로 바꿔주시고, weight 적용안된것들 마저 적용하셔서 묶음 단위 폰트 스타일로 바꿔주시면 감사하겠습니다.
일단 현재 dev 브랜치 기준으로 제가 다 바꿔놨습니다.

## 관련이슈
#47 

## 종료이슈
close #47 
